### PR TITLE
feat: override header name

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ ___
             hookRenderRoute: true, // Activate the prune during the `hook:render:route`
             hookGeneratePage: true, // Activate the prune during the `hook:generate:page`
             lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent, either as String or RegExp (a string will be converted to a case-insensitive RegExp in the MobileDetect library)
-            headerOverrideName: 'user-agent', // Value of a custom header name passed from a Lambda Edge function, or similar
+            headerName: 'user-agent', // Value of a custom header name passed from a Lambda Edge function, or similar
         },
 
     };

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ ___
             hookRenderRoute: true, // Activate the prune during the `hook:render:route`
             hookGeneratePage: true, // Activate the prune during the `hook:generate:page`
             lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent, either as String or RegExp (a string will be converted to a case-insensitive RegExp in the MobileDetect library)
+            headerOverrideName: 'user-agent', // Value of a custom header name passed from a Lambda Edge function, or similar
         },
 
     };

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,6 +96,7 @@ So, usually, for a bot or for a human, the website its almost visually the same 
             <span class="hljs-attr">hookRenderRoute</span>: <span class="hljs-literal">true</span>, <span class="hljs-comment">// Activate the prune during the `hook:render:route`</span>
             <span class="hljs-attr">hookGeneratePage</span>: <span class="hljs-literal">true</span>, <span class="hljs-comment">// Activate the prune during the `hook:generate:page`</span>
             <span class="hljs-attr">lighthouseUserAgent</span>: <span class="hljs-string">&apos;lighthouse&apos;</span>, <span class="hljs-comment">// Value of the Lighthouse UserAgent, either as String or RegExp (a string will be converted to a case-insensitive RegExp in the MobileDetect library)</span>
+            <span class="hljs-attr">headerOverrideName</span>: <span class="hljs-string">&apos;user-agent&apos;</span>, <span class="hljs-comment">// Value of a custom header name passed from a Lambda Edge function, or similar</span>
         },
 
     };
@@ -150,6 +151,6 @@ So, usually, for a bot or for a human, the website its almost visually the same 
 <p><a href="https://ko-fi.com/luxdamore"><img src="https://www.ko-fi.com/img/githubbutton_sm.svg" alt="ko-fi"></a></p>
 </section>
 </article></main></div></div>
-  
+
 
 </body></html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -96,7 +96,7 @@ So, usually, for a bot or for a human, the website its almost visually the same 
             <span class="hljs-attr">hookRenderRoute</span>: <span class="hljs-literal">true</span>, <span class="hljs-comment">// Activate the prune during the `hook:render:route`</span>
             <span class="hljs-attr">hookGeneratePage</span>: <span class="hljs-literal">true</span>, <span class="hljs-comment">// Activate the prune during the `hook:generate:page`</span>
             <span class="hljs-attr">lighthouseUserAgent</span>: <span class="hljs-string">&apos;lighthouse&apos;</span>, <span class="hljs-comment">// Value of the Lighthouse UserAgent, either as String or RegExp (a string will be converted to a case-insensitive RegExp in the MobileDetect library)</span>
-            <span class="hljs-attr">headerOverrideName</span>: <span class="hljs-string">&apos;user-agent&apos;</span>, <span class="hljs-comment">// Value of a custom header name passed from a Lambda Edge function, or similar</span>
+            <span class="hljs-attr">headerName</span>: <span class="hljs-string">&apos;user-agent&apos;</span>, <span class="hljs-comment">// Value of a custom header name passed from a Lambda Edge function, or similar</span>
         },
 
     };

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,5 +19,5 @@ export default {
     hookRenderRoute: true, // Activate in `hook:render:route`
     hookGeneratePage: true, // Activate in `hook:generate:page`
     lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent
-    headerOverrideName: 'user-agent', // Override header name, defaults to 'user-agent'
+    headerName: 'user-agent', // Override header name, defaults to 'user-agent'
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,4 +19,5 @@ export default {
     hookRenderRoute: true, // Activate in `hook:render:route`
     hookGeneratePage: true, // Activate in `hook:generate:page`
     lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent
+    headerOverrideName: 'user-agent', // Override header name, defaults to 'user-agent'
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -191,7 +191,7 @@ export default function(
                 'hook:render:route',
             );
 
-            const userAgent = req.headers[ options.headerOverrideName ]
+            const userAgent = req.headers[ options.headerName ]
                 , mobileDetect = new MobileDetect(
                     userAgent,
                 )

--- a/lib/module.js
+++ b/lib/module.js
@@ -191,7 +191,7 @@ export default function(
                 'hook:render:route',
             );
 
-            const userAgent = req.headers[ 'user-agent' ]
+            const userAgent = req.headers[ options.headerOverrideName ]
                 , mobileDetect = new MobileDetect(
                     userAgent,
                 )

--- a/test/module-headers-override.test.js
+++ b/test/module-headers-override.test.js
@@ -1,0 +1,326 @@
+import {
+    setup,
+    get,
+} from '@nuxtjs/module-test-utils';
+import { JSDOM } from 'jsdom';
+
+// Nuxt config
+import config from '../example/nuxt.config';
+
+const BASE_URL = '/';
+
+config.dev = false;
+config.router.base = BASE_URL;
+config.server.host = 'localhost';
+config.server.port = 3000;
+
+// New features
+config.pruneHtml = {
+    selectorToKeep: '.nuxt-prune--keep',
+    script: [
+        {
+            src: '#',
+            position: 'head',
+        },
+        {
+            src: '#',
+            position: 'pbody',
+        },
+        {
+            src: '#',
+        },
+    ],
+    link: [
+        {
+            src: '#',
+            rel: 'preload',
+            as: 'script',
+            position: 'phead',
+        },
+    ],
+    headerOverrideName: 'custom-name',
+};
+
+// Url generator for User Agents
+const headers = ua => (
+    ! ua
+    ? {}
+    : {
+        'custom-name': ua,
+    }
+);
+
+// Tests
+describe(
+    'module',
+    () => {
+
+        let nuxt;
+
+        beforeAll(
+            async() => {
+
+                (
+                    { nuxt } = (
+                        await setup(
+                            config
+                        )
+                    )
+                );
+
+            },
+            60000
+        );
+
+        afterAll(
+            async() => {
+
+                await nuxt.close();
+
+            }
+        );
+
+        const getElements = async(
+                selector,
+                ua
+            ) => {
+
+                const html = await get(
+                        BASE_URL,
+                        {
+                            headers: headers(
+                                ua
+                            ),
+                        }
+                    )
+                    , { window } = new JSDOM(
+                        html
+                    ).window
+                    , elements = window.document.querySelectorAll(
+                        selector
+                    )
+                ;
+
+                return elements.length;
+
+            }
+            , getHtmlDocument = async ua => {
+
+                const html = await get(
+                        BASE_URL,
+                        {
+                            headers: headers(
+                                ua
+                            ),
+                        }
+                    )
+                    , { window } = new JSDOM(
+                        html
+                    ).window
+                    , elements = window.document
+                ;
+
+                return elements;
+
+            }
+        ;
+
+        describe(
+            'human',
+            () => {
+
+                test(
+                    'preload-scripts',
+                    async() => {
+
+                        const elements = await getElements(
+                            'link[rel="preload"][as="script"]'
+                        );
+
+                        // Test
+                        expect(
+                            elements
+                        ).toBeGreaterThanOrEqual(
+                            0
+                        );
+
+                    }
+                );
+
+                test(
+                    'scripts',
+                    async() => {
+
+                        const elements = await getElements(
+                            'script:not([type="application/ld+json"])',
+                        );
+
+                        // Test
+                        expect(
+                            elements
+                        ).toBeGreaterThanOrEqual(
+                            1
+                        );
+
+                    }
+                );
+
+                test(
+                    'scripts-maintained',
+                    async() => {
+
+                        const elements = await getElements(
+                            `script${ config.pruneHtml.selectorToKeep }`,
+                        );
+
+                        // Test
+                        expect(
+                            elements
+                        ).toEqual(
+                            1
+                        );
+
+                    }
+                );
+
+                test(
+                    'scripts-positions',
+                    async() => {
+
+                        const elements = await getHtmlDocument();
+
+                        // Test
+                        expect(
+                            elements.head.firstChild.tagName !== 'LINK'
+                        ).toEqual(
+                            true
+                        );
+
+                        expect(
+                            elements.head.lastChild.tagName !== 'SCRIPT'
+                        ).toEqual(
+                            true
+                        );
+
+                        expect(
+                            elements.body.firstChild.tagName !== 'SCRIPT'
+                        ).toEqual(
+                            true
+                        );
+
+                        expect(
+                            elements.body.lastChild.tagName !== 'SCRIPT'
+                        ).toEqual(
+                            true
+                        );
+
+                    }
+                );
+
+            }
+        );
+
+        describe(
+            'bot',
+            () => {
+
+                const USER_AGENT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+
+                test(
+                    'preload-scripts',
+                    async() => {
+
+                        const elements = await getElements(
+                            'link[rel="preload"][as="script"]',
+                            USER_AGENT
+                        );
+
+                        // Test
+                        expect(
+                            elements
+                        ).toEqual(
+                            1
+                        );
+
+                    }
+                );
+
+                test(
+                    'scripts',
+                    async() => {
+
+                        const elements = await getElements(
+                            'script:not([type="application/ld+json"])',
+                            USER_AGENT
+                        );
+
+                        // Test
+                        expect(
+                            elements
+                        ).toEqual(
+                            4
+                        );
+
+                    }
+                );
+
+                test(
+                    'scripts-maintained',
+                    async() => {
+
+                        const elements = await getElements(
+                            `script${ config.pruneHtml.selectorToKeep }`,
+                            USER_AGENT
+                        );
+
+                        // Test
+                        expect(
+                            elements
+                        ).toEqual(
+                            1
+                        );
+
+                    }
+                );
+
+                test(
+                    'scripts-positions',
+                    async() => {
+
+                        const elements = await getHtmlDocument(
+                            USER_AGENT,
+                        );
+
+                        // Test
+                        expect(
+                            elements.head.firstChild.tagName === 'LINK'
+                        ).toEqual(
+                            true
+                        );
+
+                        expect(
+                            elements.head.lastChild.tagName === 'SCRIPT'
+                        ).toEqual(
+                            true
+                        );
+
+                        expect(
+                            elements.body.firstChild.tagName === 'SCRIPT'
+                        ).toEqual(
+                            true
+                        );
+
+                        expect(
+                            elements.body.lastChild.tagName === 'SCRIPT'
+                        ).toEqual(
+                            true
+                        );
+
+                    }
+                );
+
+            }
+        );
+
+    }
+);

--- a/test/module-headers-override.test.js
+++ b/test/module-headers-override.test.js
@@ -38,7 +38,7 @@ config.pruneHtml = {
             position: 'phead',
         },
     ],
-    headerOverrideName: 'custom-name',
+    headerName: 'custom-name',
 };
 
 // Url generator for User Agents


### PR DESCRIPTION
I'd prefer not to mess with the `user-agent` because it might impact my cloudfront routing and who knows what else.

I use a lambda function and there I can pass and read form a custom header name.

Thank you.