### PR TITLE
Integrate ability to add additional headers in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ ___
             hookRenderRoute: true, // Activate the prune during the `hook:render:route`
             hookGeneratePage: true, // Activate the prune during the `hook:generate:page`
             lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent, either as String or RegExp (a string will be converted to a case-insensitive RegExp in the MobileDetect library)
-            headerName: 'user-agent', // Value of a custom header name passed from a Lambda Edge function, or similar
+            headerName: 'user-agent', // Value of a custom header name passed from a Lambda Edge function, or similar,
+            additionalHeaders: {}, // Pass additional headers in response from server, if bot/lighthouse/.. hits (Usage:- Bypass template caching in case of these headers, Use seperate caching for bot hits etc..) `ex. { new-header: 'header-value' }`
         },
 
     };

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,5 +20,5 @@ export default {
     hookGeneratePage: true, // Activate in `hook:generate:page`
     lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent
     headerName: 'user-agent', // Override header name, defaults to 'user-agent'
-    additionalHeaders: {}, // Pass additional headers in request to server, if bot/lighthouse/.. hits (Usage:- Bypass template caching in case of these headers, Use seperate caching for bot hits etc..) `ex. { new-header: 'header-value' }`
+    additionalHeaders: {}, // Pass additional headers in response from server, if bot/lighthouse/.. hits (Usage:- Bypass template caching in case of these headers, Use seperate caching for bot hits etc..) `ex. { new-header: 'header-value' }`
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,4 +20,5 @@ export default {
     hookGeneratePage: true, // Activate in `hook:generate:page`
     lighthouseUserAgent: 'lighthouse', // Value of the Lighthouse UserAgent
     headerName: 'user-agent', // Override header name, defaults to 'user-agent'
+    additionalHeaders: {}, // Pass additional headers in request to server, if bot/lighthouse/.. hits (Usage:- Bypass template caching in case of these headers, Use seperate caching for bot hits etc..) `ex. { new-header: 'header-value' }`
 };

--- a/lib/module.js
+++ b/lib/module.js
@@ -2,6 +2,9 @@
 import cheerio from 'cheerio';
 import MobileDetect from 'mobile-detect';
 
+// Helper functions
+import { cleanHeaders } from '../utils/helpers';
+
 // Config
 import * as PACKAGE from '../package.json';
 import defaultConfig from './config';
@@ -214,6 +217,13 @@ export default function nuxtPruneHtml(
             ;
 
             if( ( options.ignoreBotOrLighthouse || isBot || isLighthouse ) || isMatched ) {
+
+                req.headers = {
+                    ... req.headers,
+                    ... cleanHeaders(
+                    options.additionalHeaders
+                    ),
+                };
 
                 result.html = pruneHtml(
                     result.html,

--- a/lib/module.js
+++ b/lib/module.js
@@ -185,7 +185,9 @@ export default function nuxtPruneHtml(
         (
             _,
             result,
-            { req },
+            {
+ req, res,
+},
         ) => {
 
             ! options.hideGenericMessagesInConsole && logger.info(
@@ -218,8 +220,8 @@ export default function nuxtPruneHtml(
 
             if( ( options.ignoreBotOrLighthouse || isBot || isLighthouse ) || isMatched ) {
 
-                req.headers = {
-                    ... req.headers,
+                res.headers = {
+                    ... res.headers,
                     ... cleanHeaders(
                     options.additionalHeaders
                     ),

--- a/lib/module.js
+++ b/lib/module.js
@@ -3,7 +3,7 @@ import cheerio from 'cheerio';
 import MobileDetect from 'mobile-detect';
 
 // Helper functions
-import { cleanHeaders } from '../utils/helpers';
+import { setHeaders } from '../utils/helpers';
 
 // Config
 import * as PACKAGE from '../package.json';
@@ -220,13 +220,10 @@ export default function nuxtPruneHtml(
 
             if( ( options.ignoreBotOrLighthouse || isBot || isLighthouse ) || isMatched ) {
 
-                res.headers = {
-                    ... res.headers,
-                    ... cleanHeaders(
-                    options.additionalHeaders
-                    ),
-                };
-
+                setHeaders(
+res,
+options.additionalHeaders
+);
                 result.html = pruneHtml(
                     result.html,
                     options,

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,13 @@
+export function cleanHeaders(
+ headers = {}
+) {
+
+    for( const name in headers ) {
+
+        if( ! headers[ name ] )
+            delete this.headers[ name ];
+
+    }
+    return headers;
+
+}

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,13 +1,42 @@
-export function cleanHeaders(
+function cleanHeaders(
  headers = {}
 ) {
 
+    if( headers && typeof headers === 'object' ) {
+
     for( const name in headers ) {
 
-        if( ! headers[ name ] )
-            delete this.headers[ name ];
+            if( name && ! headers[ name ] )
+                delete headers[ name ];
 
-    }
+        }
+
+}
     return headers;
+
+}
+
+export function setHeaders(
+ res, headers
+) {
+
+    const cleanedHeaders = cleanHeaders(
+ headers
+);
+
+    if( cleanedHeaders && Object.keys(
+ cleanedHeaders
+).length ) {
+
+for( const name in cleanedHeaders ) {
+
+res.setHeader(
+ name,
+headers[ name ]
+);
+
+}
+
+}
 
 }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,34 +1,12 @@
-function cleanHeaders(
- headers = {}
-) {
-
-    if( headers && typeof headers === 'object' ) {
-
-    for( const name in headers ) {
-
-            if( name && ! headers[ name ] )
-                delete headers[ name ];
-
-        }
-
-}
-    return headers;
-
-}
-
 export function setHeaders(
- res, headers
+ res, headers = {}
 ) {
 
-    const cleanedHeaders = cleanHeaders(
- headers
-);
+for( const name in headers ) {
 
-    if( cleanedHeaders && Object.keys(
- cleanedHeaders
-).length ) {
-
-for( const name in cleanedHeaders ) {
+    if( ! headers[ name ] )
+        delete headers[ name ];
+    else {
 
 res.setHeader(
  name,
@@ -40,3 +18,4 @@ headers[ name ]
 }
 
 }
+


### PR DESCRIPTION
This feature will be helpful for those, who are using template caching mechanism such that you can pass additional headers in response if a bot/lighthouse hits. This will tell the cache that the hit is from a bot so you can manipulate the actions. Whether you can bypass the cache/Build a seperate cache for bots etc..